### PR TITLE
feat: support multiple files in `setup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# CHANGELOG
+
+## 0.2.0 (yyyy-mm-dd)
+
+- Multiple files can now be used as input:
+  - `-f` can be used multiple times;
+  - `TSetupParams` has been modified to accept a list of files;
+- Changed behaviour of the default command (`run`):
+  - `obelisq [run] <script>` has been replaced with `obelisq [run] -s "<script>"`, e.g. `obelisq -s "node -e \"console.log('Hello world')\"`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # CHANGELOG
 
-## 0.2.0 (yyyy-mm-dd)
+## 0.2.0 (2025-04-18)
 
-- Multiple files can now be used as input:
-  - `-f` can be used multiple times;
-  - `TSetupParams` has been modified to accept a list of files;
-- Changed behaviour of the default command (`run`):
-  - `obelisq [run] <script>` has been replaced with `obelisq [run] -s "<script>"`, e.g. `obelisq -s "node -e \"console.log('Hello world')\"`;
+- `TSetupParams` now requires an array of files instead of a single file.
+- The default command behavior is updated to use the new `-s` option for running scripts, and the CLI now requires a repeatable `-f` option.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2025 Carlos Menezes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ await setup({
 });
 ```
 
-You can also run `$ obelisq -f <patb> -s "<script>"` to load the environment variables from the file at `path` into `process.env` for another Node script. Say you have a file `log-env.js` which simply executes `console.log(process.env)`. You can inject the values from your environment file into `process.env` by running the following command:
+You can also run `$ obelisq -f <path> -s "<script>"` to load the environment variables from the file at `path` into `process.env` for another Node script. Say you have a file `log-env.js` which simply executes `console.log(process.env)`. You can inject the values from your environment file into `process.env` by running the following command:
 
 ```sh
 $ obelisq -f .env -s "node log-env.js"

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ In the entrypoint to your app (e.g. `index.ts`), call `setup` to load your `.env
 // index.ts
 import { setup } from "obelisq";
 
-// Takes additional, optional configuration.
-// Returns a list of entries (`TEnvironmentLineKeyValue`) which may be used for e.g. validation purposes.
-await setup();
+await setup({
+  files: [".env"], // Mandatory. No assumptions are made about the file name. Add as many as you want.
+});
 ```
 
-You can also run `$ obelisq <script>` to load the environment variables into `process.env` for another Node script. Say you have a file `log-env.js` which simply executes `console.log(process.env)`. You can inject the values from your environment file into `process.env` by running the following command:
+You can also run `$ obelisq -f <patb> -s "<script>"` to load the environment variables from the file at `path` into `process.env` for another Node script. Say you have a file `log-env.js` which simply executes `console.log(process.env)`. You can inject the values from your environment file into `process.env` by running the following command:
 
 ```sh
-obelisq node log-env.js
+$ obelisq -f .env -s "node log-env.js"
 ```
 
 The output should contain:
 
 ```sh
-$ obelisq node log-env.js
+$ obelisq -f .env -s "node log-env.js"
 
 {
   // ...
@@ -53,7 +53,7 @@ $ obelisq node log-env.js
 You can generate a library which provides minimal type-safety when accessing the environment variables.
 
 ```sh
-obelisq generate [-o <string>]
+obelisq -f .env generate [-o <string>]
 ```
 
 This will output `obelisq.ts` (unless specified differently with `-o` — "output path") which exports `environment`, a function which takes a single argument of type `TObelisqEnvironmentKeys`. What is `TObelisqEnvironmentKeys`? It's a type that extends a `Record` where the `keys` are the keys of your environment file and the values are the (assumed) type of the value, e.g.:
@@ -74,7 +74,7 @@ SUPER_SECRET_KEY=your_secret_key
 API_VERSION=2${SUPER_SECRET_KEY}
 ```
 
-Running `$ obelisq` will add the following to `process.env`:
+Running `$ obelisq -f .env ` will add the following to `process.env`:
 
 ```ts
 SUPER_SECRET_KEY: 'your_secret_key',
@@ -82,3 +82,26 @@ API_VERSION: '2your_secret_key'
 ```
 
 Note that it's advisable to run `$ obelisq generate` every time you change your `.env` as expansion may change the value's assumed type.
+
+## Multiple files
+
+You can load multiple files by passing an array of file names to the `setup` function. The files are loaded in the order they are passed, so if a variable is defined in multiple files, the last one will take precedence.
+
+Say you have two files:
+
+```sh
+# .env
+SUPER_SECRET_KEY=your_secret_key
+# .env.local
+SUPER_SECRET_KEY=your_local_secret_key
+```
+
+If you call `setup` like this:
+
+```ts
+await setup({
+  files: [".env", ".env.local"],
+});
+```
+
+The value of `SUPER_SECRET_KEY` in `process.env` will be `your_local_secret_key`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obelisq",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Load environment variables from `.env` into `NodeJS.ProcessEnv`.",
   "main": "dist/library/index.js",
   "bin": {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -1,0 +1,5 @@
+export const repeatable = (value: string, previous: string[]) => {
+  const set = new Set(previous);
+  set.add(value);
+  return Array.from(set);
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { setup } from "../library";
 import { generateObelisqFile } from "../library/generated";
 import { parseEnvironment, TEnvironmentLineKeyValue } from "../library/parser";
 import spawn from "cross-spawn";
+import { repeatable } from "./helpers";
 
 const program = new Command();
 
@@ -12,7 +13,9 @@ program.name("obelisq").description("Obelisq CLI").version(packageJson.version);
 
 program
   .command("run", { isDefault: true })
-  .option("-f, --file <string>", "path to environment file", ".env")
+  .option("-f, --file <string>", "path to environment file", repeatable, [
+    ".env",
+  ])
   .allowExcessArguments(true)
   .action(async (options) => {
     await setup({ file: options.file });
@@ -54,7 +57,7 @@ program
     const content = (await readFile(".env", { encoding: "utf-8" })).split("\n");
     const parsedLines = await parseEnvironment({ content });
     const entries = parsedLines.filter(
-      (entry) => entry.kind === "key-value"
+      (entry) => entry.kind === "key-value",
     ) as TEnvironmentLineKeyValue[];
 
     const outputPath = options.output || "obelisq.ts";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,11 @@ program.name("obelisq").description("Obelisq CLI").version(packageJson.version);
 
 program
   .command("run", { isDefault: true })
-  .requiredOption("-f, --file <string>", "path to environment file", repeatable)
+  .requiredOption(
+    "-f, --file <string>",
+    "paths to environment files",
+    repeatable,
+  )
   .option("-s, --spawn <string>", "spawn a process with the given command")
   .allowExcessArguments(true)
   .action(async (options) => {

--- a/src/library/environment.ts
+++ b/src/library/environment.ts
@@ -1,13 +1,14 @@
-import { TEnvironmentLineKeyValue } from "./parser";
+import { TParseEnvironmentReturnType } from "./parser";
 
 type TExtendEnvironmentParams = {
-  entries: TEnvironmentLineKeyValue[];
+  entries: TParseEnvironmentReturnType;
 };
 
 export const extendEnvironment = async ({
   entries,
 }: TExtendEnvironmentParams) => {
-  for (const { key, value } of entries) {
+  for (const key in entries) {
+    const { value } = entries[key];
     process.env[key] = value;
   }
 };

--- a/src/library/generated.ts
+++ b/src/library/generated.ts
@@ -1,15 +1,15 @@
-import { TEnvironmentLineKeyValue } from "./parser";
+import { TParseEnvironmentReturnType } from "./parser";
 
 type TGenerateObelisqFileParams = {
-  entries: TEnvironmentLineKeyValue[];
+  entries: TParseEnvironmentReturnType;
 };
 
 const generateEnvironmentKeysType = ({
   entries,
 }: Pick<TGenerateObelisqFileParams, "entries">) => {
   return `export type TObelisqEnvironmentKeys = {
-  ${entries
-    .map(({ key, metadata }) => `${key}: ${metadata.type};`)
+  ${Object.entries(entries)
+    .map(([key, { metadata }]) => `${key}: ${metadata.type};`)
     .join("\n  ")}
 };`;
 };

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -1,34 +1,32 @@
 import { PathLike } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { parseEnvironment, TEnvironmentLineKeyValue } from "./parser";
+import { parseEnvironment, TParseEnvironmentReturnType } from "./parser";
 import { extendEnvironment } from "./environment";
 
 type TSetupParams = {
-  /**
-   * Path to the `.env` file to be parsed.
-   */
-  file?: PathLike[];
+  files: PathLike[];
 };
 
 export const setup = async (
-  options?: TSetupParams,
-): Promise<TEnvironmentLineKeyValue[]> => {
-  const content = (
-    await readFile(options?.file ?? ".env", { encoding: "utf-8" })
-  ).split("\n");
-  const parsedLines = await parseEnvironment({ content });
+  options: TSetupParams,
+): Promise<TParseEnvironmentReturnType> => {
+  const mergedFilesContent = (
+    await Promise.all(
+      options.files.map(async (file) => {
+        const content = (await readFile(file, { encoding: "utf-8" })).split(
+          "\n",
+        );
+        return content;
+      }),
+    )
+  ).flat();
 
-  /**
-   * Filter out comments and empty lines.
-   * As noted in `parseEnvironment`, the return type is a union of all possible line types.
-   * We may eventually use the other types, but for now we only care about key-value pairs.
-   */
-  const entries = parsedLines.filter(
-    (entry) => entry.kind === "key-value",
-  ) as TEnvironmentLineKeyValue[];
+  console.log(mergedFilesContent);
 
+  const entries = await parseEnvironment({
+    content: mergedFilesContent,
+  });
   await extendEnvironment({ entries });
+
   return entries;
 };
-
-export type { TEnvironmentLineKeyValue };

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -21,8 +21,6 @@ export const setup = async (
     )
   ).flat();
 
-  console.log(mergedFilesContent);
-
   const entries = await parseEnvironment({
     content: mergedFilesContent,
   });

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -24,6 +24,7 @@ export const setup = async (
   const entries = await parseEnvironment({
     content: mergedFilesContent,
   });
+
   await extendEnvironment({ entries });
 
   return entries;

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -7,11 +7,11 @@ type TSetupParams = {
   /**
    * Path to the `.env` file to be parsed.
    */
-  file?: PathLike;
+  file?: PathLike[];
 };
 
 export const setup = async (
-  options?: TSetupParams
+  options?: TSetupParams,
 ): Promise<TEnvironmentLineKeyValue[]> => {
   const content = (
     await readFile(options?.file ?? ".env", { encoding: "utf-8" })
@@ -24,7 +24,7 @@ export const setup = async (
    * We may eventually use the other types, but for now we only care about key-value pairs.
    */
   const entries = parsedLines.filter(
-    (entry) => entry.kind === "key-value"
+    (entry) => entry.kind === "key-value",
   ) as TEnvironmentLineKeyValue[];
 
   await extendEnvironment({ entries });

--- a/src/library/parser.ts
+++ b/src/library/parser.ts
@@ -62,7 +62,7 @@ export const parseEnvironment = async ({
 }: TParseEnvironmentParams): Promise<TParseEnvironmentReturnType> => {
   // Remove empty lines and comments
   const sanitizedLines = content.filter(
-    (line) => line.trim() !== "" || line.trim().startsWith("#"),
+    (line) => line.trim() !== "" && line.trim().startsWith("#"),
   );
 
   const entries: TParseEnvironmentReturnType = {};

--- a/src/library/parser.ts
+++ b/src/library/parser.ts
@@ -62,7 +62,7 @@ export const parseEnvironment = async ({
 }: TParseEnvironmentParams): Promise<TParseEnvironmentReturnType> => {
   // Remove empty lines and comments
   const sanitizedLines = content.filter(
-    (line) => line.trim() !== "" || line.trim().startsWith("#"),
+    (line) => line.trim() !== "" && !line.trim().startsWith("#"),
   );
 
   const entries: TParseEnvironmentReturnType = {};

--- a/src/library/parser.ts
+++ b/src/library/parser.ts
@@ -62,7 +62,7 @@ export const parseEnvironment = async ({
 }: TParseEnvironmentParams): Promise<TParseEnvironmentReturnType> => {
   // Remove empty lines and comments
   const sanitizedLines = content.filter(
-    (line) => line.trim() !== "" && line.trim().startsWith("#"),
+    (line) => line.trim() !== "" || line.trim().startsWith("#"),
   );
 
   const entries: TParseEnvironmentReturnType = {};

--- a/src/library/tests/environment.test.ts
+++ b/src/library/tests/environment.test.ts
@@ -5,22 +5,20 @@ import assert from "assert";
 describe("environment.ts", () => {
   it("should extend the environment", async () => {
     await extendEnvironment({
-      entries: [
-        {
-          key: "TEST_KEY",
+      entries: {
+        TEST_KEY: {
           value: "TEST_VALUE",
-          kind: "key-value",
           metadata: {
             type: "string",
           },
         },
-      ],
+      },
     });
 
     assert.equal(
       process.env.TEST_KEY,
       "TEST_VALUE",
-      "Environment variable not set correctly"
+      "Environment variable not set correctly",
     );
   });
 });


### PR DESCRIPTION
- Multiple files can now be used as input:
  - `-f` can be used multiple times;
  - `TSetupParams` has been modified to accept a list of files;
- Changed behaviour of the default command (`run`):
  - `obelisq [run] <script>` has been replaced with `obelisq [run] -s "<script>"`, e.g. `obelisq -s "node -e \"console.log('Hello world')\"`;